### PR TITLE
update-travis-and-rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,17 +5,6 @@ AllCops:
     - Gemfile
     - '*.gemspec'
 
-# I like this Metric in principle, but I don't like the default max of
-# 15.
-#
-# Also, as per Metrics/ClassLength IMO this kind of limit should not
-# apply to test code (I get up to 318 over there).
-#
-Metrics/AbcSize:
-  Max: 100
-  Exclude:
-    - 'test/**/*.rb'
-
 # Broadly speaking, test code gets a pass for most of the Metrics family.
 #
 # IMO test code is not the place get pedantic about class length,
@@ -26,9 +15,6 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'test/**/*.rb'
-
-# Ditto I believe in more permissive rules in test code.
-#
 Metrics/ClassLength:
   Max: 400
   Exclude:
@@ -37,18 +23,31 @@ Metrics/ClassLength:
 # Redis::ScriptManager#eval_gently is indeed overly complex but I am
 # happy with it until the next time something goes wrong.
 #
+# I like Metrics/CyclomaticComplexity in principle, but I don't like
+# the default max of 15.
+#
 # Also ditto I believe in more permissive rules in test code.
+#
+# Also, as per Metrics/ClassLength IMO this kind of limit should not
+# apply to test code (I get up to 318 over there).
 #
 Metrics/CyclomaticComplexity:
   Max: 30
-  Exclude:
-    - 'test/**/*.rb'
-Metrics/MethodLength:
+Metrics/PerceivedComplexity:
+  Max: 30
+Metrics/AbcSize:
   Max: 100
   Exclude:
     - 'test/**/*.rb'
-Metrics/PerceivedComplexity:
-  Max: 21
+
+# I like this Metric in principle, but I don't like the default max of
+# 10.
+#
+# Also, as per Metrics/ClassLength IMO this kind of limit should not
+# apply to test code.
+#
+Metrics/MethodLength:
+  Max: 100
   Exclude:
     - 'test/**/*.rb'
 
@@ -60,140 +59,16 @@ Metrics/PerceivedComplexity:
 Layout:
   Enabled: false
 
+# As a group, the Style cops are bewilderingly opiniated.
+#
+# In some cases IMO they are harmful e.g. Style/TernaryParentheses.
+#
+# I reject these cops.
+#
+Style:
+  Enabled: false
+
 # I like a lot of the Lint tests, but not these.
 #
 Lint/AmbiguousBlockAssociation:           # obnoxiously rejects idiomatic Ruby
-  Enabled: false
-
-# This does no more than insist I type "format" instead of "sprintf",
-# where the two are aliases.
-#
-Style/FormatString:
-  Enabled: false
-
-# This complains that:
-#
-#   if foo
-#     foo.bar
-#   end
-#
-# could instead be:
-#
-#   foo.bar if foo
-#
-# ...which I reject, not least because the former is a lot easier to
-# fit into an 80 character line.
-#
-Style/GuardClause:
-  Enabled: false
-
-# There is nothing wrong with Ruby 1.9 Hash syntax.
-#
-Style/HashSyntax:
-  Enabled: false
-
-# No.  Indeed, postfix if can often drive a line over 80 columns wide.
-#
-Style/IfUnlessModifier:
-  Enabled: false
-
-# No.  There is nothing wrong with "if !foo".
-#
-# As far as I'm concerned, "unless" is in poor taste because it means
-# I have to think in English in two different logical senses - and
-# English is a poor language for logical senses.
-#
-Style/NegatedIf:
-  Enabled: false
-
-# No.
-#
-# I can catenate strings with + if I want to.  Indeed, it looks better
-# in my editor.
-#
-Style/LineEndConcatenation:
-  Enabled: false
-
-# Too pedantic.
-#
-Style/NumericLiterals:
-  Enabled: false
-
-# This complains that:
-#
-#   raise RuntimeError, "foo"
-#
-# Does not need the RuntimeError because it is redundant.
-#
-# I do not accept a requirement not to be explicit.
-#
-Style/RedundantException:
-  Enabled: false
-
-# "Do not use semicolons to terminate expressions."
-#
-# That's great when I terminate a single-line expression with a
-# redundant semicolo because I forget I'm not using C.
-#
-# But when I'm using a semicolon to separate two expressions there is
-# no other choice.  So this really ought to be Style/OneExprPerLine,
-# which I reject.
-#
-Style/Semicolon:
-  Enabled: false
-
-# No.
-#
-# Some lines must have '\"'.  It is ugly to use a mix of '"' and '\''
-# in LoCs which are close to one another.  Therefore, banning '"' if
-# '"' is not strictly necessary drives visual inconsistency.
-#
-Style/StringLiterals:
-  Enabled: false
-
-# This is the same kind of obnoxious pedantry which drove Hungarian
-# Notation.
-#
-# The [] literal syntax is perfectly servicable and there is no point
-# _tightly_ coupling it to the content of the array.  That's why we
-# have context-free grammers!
-#
-Style/SymbolArray:
-  Enabled: false
-
-# Shockingly, this cop requires us to *OMIT*, not *INCLUDE* parens in
-# ternery conditons.
-#
-# IMO this one is actively harmful in that it discourages attention to
-# clarity and avoiding some nasty precedence surprises.
-#
-Style/TernaryParentheses:
-  Enabled: false
-
-# I am a huge fan of using trailing commas when I break an argument
-# list down one-per line.
-#
-# As such, I reject this test.
-#
-Style/TrailingCommaInLiteral:
-  Enabled: false
-
-# No.  attr_writer, attr_reader, etc. are strictly optional.
-#
-# If I want to use the longer, less sugary form that is my business.
-#
-# I especially believe this where, for instance, I have a trivial
-# reader but a non-trivial writer.  I want consistency between them -
-# which would be prohibited by this requirement.
-Style/TrivialAccessors:
-  Enabled: false
-
-# Too pedantic.  I am starting to think I should switch from "opt out"
-# to "opt in" on the Style family.
-#
-Style/WordArray:
-  Enabled: false
-Style/YodaCondition:
-  Enabled: false
-Style/ZeroLengthPredicate:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 before_install:
-  - gem install bundler -v 1.14.6
+  - gem install bundler -v 1.16.1
   - gem install rubocop
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ rvm:
   - 2.5.0
 script:
   - bundle exec rubocop --display-cop-names --display-style-guide
-  - bundle exec rake test
+  - bundle exec env REDIS_URL=redis://localhost:6379 rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ services:
   - redis-server
 rvm:
   - 2.1.6
+  - 2.2.9
+  - 2.4.3
+  - 2.5.0
 script:
-  - rubocop
-  - bundle exec env REDIS_URL=redis://localhost:6379 rake test
+  - bundle exec rubocop --display-cop-names --display-style-guide
+  - bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# 0.0.5 (2018-03-26)
+- Expanded .travis.yml to cover more rvm versions.
+- Shrink Rubocop coverage to exclude `Style/*`.
+- Moves version history out into CHANGELOG.md.
+
+# 0.0.4 (2017-09-18)
+- Rubocop polish and defiance.
+
+# 0.0.3 (2017-08-29)
+- Got .travis.yml working with a live redis-server.
+- Initial Rubocop integration.
+- Misc cleanup.
+
+# 0.0.2 (2017-08-29)
+
+- Broke out into Prosperworks/redis-script_manager, make public.
+
+# 0.0.1 (prehistory)
+
+- Still in Prosperworks/ALI/vendor/gems/redis-script_manager.

--- a/lib/redis/script_manager.rb
+++ b/lib/redis/script_manager.rb
@@ -247,6 +247,15 @@ class Redis
     #
     class Configuration
 
+      def initialize
+        @do_preload         = nil
+        @max_tiny_lua       = nil
+        @preload_cache_size = nil
+        @do_minify_lua      = nil
+        @stats_prefix       = nil
+        @statsd             = nil
+      end
+
       # Defaults to nil. If non-nil, lots of stats will be tracked via
       # statsd.increment and statsd.timing.
       #

--- a/lib/redis/script_manager/version.rb
+++ b/lib/redis/script_manager/version.rb
@@ -3,23 +3,8 @@ class Redis
     #
     # Version plan/history:
     #
-    # 0.0.1 - Still in Prosperworks/ALI/vendor/gems/redis-script_manager.
     #
-    # 0.0.2 - Broke out into Prosperworks/redis-script_manager, make public.
     #
-    # 0.0.3 - Got .travis.yml working with a live redis-server.
-    #
-    #         Initial Rubocop integration.
-    #
-    #         Misc cleanup.
-    #
-    # 0.0.4 - Rubocop polish and defiance.
-    #
-    # 0.1.0 - (future) Big README.md and Rdoc update, solicit feedback
-    #         from select external beta users.
-    #
-    # 0.2.0 - (future) Incorporate feedback, announce.
-    #
-    VERSION = '0.0.4'.freeze
+    VERSION = '0.0.5'.freeze
   end
 end

--- a/redis-script_manager.gemspec
+++ b/redis-script_manager.gemspec
@@ -21,10 +21,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler',         '~> 1.14'
-  spec.add_development_dependency 'rake',            '~> 10.0'
-  spec.add_development_dependency 'minitest',        '~> 5.0'
-  spec.add_development_dependency 'redis',           '~> 3.2'
+  spec.add_development_dependency 'bundler',         '~> 1.16.1'
+  spec.add_development_dependency 'minitest',        '~> 5.11.3'
+  spec.add_development_dependency 'rake',            '~> 12.3.1'
   spec.add_development_dependency 'redis-namespace', '~> 1.5'
+  spec.add_development_dependency 'rubocop',         '~> 0.54.0'
+
+  spec.add_runtime_dependency     'redis',           '~> 3.2'
 
 end

--- a/test/redis/script_manager_test.rb
+++ b/test/redis/script_manager_test.rb
@@ -454,8 +454,12 @@ class Redis
         ].each do |args,expect,expect_stats|
           got       = Redis::ScriptManager.eval_gently(*args)
           got_stats = statsd.flush
-          assert_equal expect,       got,       args
-          assert_equal expect_stats, got_stats, args
+          if got
+            assert_equal expect,       got,       args
+          else
+            assert_nil                 got,       args
+          end
+          assert_equal   expect_stats, got_stats, args
         end
         #
         # Bogus args


### PR DESCRIPTION
PR for redis-key_hash.  Bumps version to 0.0.5.

Revises Rubocop policy to match redis-ick, adds CHANGELOG.md, updates runtime deps, expands TravisCI to test across more Ruby versions.